### PR TITLE
Updated to SDK30; enabled cert download on Android11+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,14 +3,14 @@ apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
         applicationId "com.ffrktoolkit.ffrktoolkithelper"
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 29
         versionCode 23
         versionName "1.1.9"
@@ -39,7 +39,8 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.vectordrawable:vectordrawable:1.2.0-alpha02'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.1.0'
-    implementation 'org.littleshoot:littleproxy:1.1.2'
+    //implementation 'org.littleshoot:littleproxy:1.1.2'
+    //implementation 'xyz.rogfam:littleproxy:2.0.5'
     implementation 'com.github.ganskef:littleproxy-mitm:1.1.0'
     //implementation 'net.lightbody.bmp:mitm:2.1.4'
     //implementation 'net.lightbody.bmp:browsermob-core:2.1.5'

--- a/app/src/main/java/com/ffrktoolkit/ffrktoolkithelper/util/FfrkFilterAdapter.java
+++ b/app/src/main/java/com/ffrktoolkit/ffrktoolkithelper/util/FfrkFilterAdapter.java
@@ -1,12 +1,13 @@
 package com.ffrktoolkit.ffrktoolkithelper.util;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.ffrktoolkit.ffrktoolkithelper.ProxyService;
 import com.google.common.net.HttpHeaders;
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
-import org.apache.commons.lang3.StringUtils;
+//import org.apache.commons.lang3.StringUtils;
 import org.littleshoot.proxy.HttpFiltersAdapter;
 
 import java.net.URL;
@@ -75,7 +76,8 @@ public class FfrkFilterAdapter extends HttpFiltersAdapter {
                     URL urlPath = new URL(uri);
                     Log.d(LOG_TAG, "Response path: " + urlPath.getPath());
                     proxyService.parseFfrkResponse(originalRequest, responseContent);
-                    Log.d(LOG_TAG, StringUtils.truncate(responseContent, 1000));
+                    //Log.d(LOG_TAG, StringUtils.truncate(responseContent, 1000));
+                    Log.d(LOG_TAG, TextUtils.substring(responseContent, 0, 1000));
                 } catch (Exception e) {
                     Log.e(LOG_TAG, "Error in response processing.", e);
                     crashlytics.log("Exception while parsing response content.");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,5 +97,9 @@
     <string name="stamina_restored">Stamina fully restored!</string>
 
     <string name="error_proxy_already_started">Proxy already running or another application is using port\u0020</string>
+
+    <string name="cert_manual_install_11">You need to manually install the certificate on Android 11 and higher</string>
+    <string name="cert_extracted">Certificate has been extracted</string>
+    <string name="error">Error</string>
 </resources>
 


### PR DESCRIPTION
lowered min SDK to 16 from 19, raised build SDK to 30 to support Android 11 properly.

No improvements regarding actual interception yet, but added certificate download to the "Install certificate" button to create a copy of the CA for manual installation on 11+ devices.